### PR TITLE
Recipe to build an Apptainer with Flywheel

### DIFF
--- a/apptainer/.gitignore
+++ b/apptainer/.gitignore
@@ -1,0 +1,2 @@
+# apptainer/singularity container
+*.sif

--- a/apptainer/README.md
+++ b/apptainer/README.md
@@ -6,6 +6,8 @@ Uses:
 
 -   Ubuntu 22.04 (Jammy)
 -   Ubuntu-provided Python 3.10.12 instead of Anaconda
+-   Latest [Flywheel CLI](https://flywheel-io.gitlab.io/tools/app/cli/0.34/flyw/) installed 
+    using [https://storage.googleapis.com/flywheel-dist/fw-cli/stable/install.sh](https://storage.googleapis.com/flywheel-dist/fw-cli/stable/install.sh)
 
 ## Build instructions
 

--- a/apptainer/README.md
+++ b/apptainer/README.md
@@ -1,0 +1,17 @@
+# flywheel Apptainer container
+
+## Overview
+
+Uses:
+
+-   Ubuntu 22.04 (Jammy)
+-   Ubuntu-provided Python 3.10.12 instead of Anaconda
+
+## Build instructions
+
+``` bash
+apptainer build flywheel.sif flywheel.def
+```
+
+Or use the provided `build_flywheel.sh` script with
+appropriate modifications to submit to Slurm to build.

--- a/apptainer/build_flywheel.sh
+++ b/apptainer/build_flywheel.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#SBATCH --job-name=build_flywheel
+#SBATCH --output=build_flywheel-%j.out
+#SBATCH --partition=short
+#SBATCH --cpus-per-task=8
+#SBATCH --mem-per-cpu=4GB
+#SBATCH --time=0:30:00
+
+apptainer build ${TMPDIR}/flywheel.sif flywheel.def
+
+[[ -f ${TMPDIR}/flywheel.sif ]] && mv ${TMPDIR}/flywheel.sif .

--- a/apptainer/flywheel.def
+++ b/apptainer/flywheel.def
@@ -6,8 +6,9 @@ From: ubuntu:22.04
 %environment
 
 export FLYWHEELDIR=/opt/flywheel
+export FW_CLI_INSTALL_DIR=/opt/flywheel-cli
 export PYTHONPATH=/opt/flywheel/lib
-export PATH=/opt/flywheel/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH=/opt/flywheel/bin:/opt/flywheel-cli:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 %post
 
@@ -16,9 +17,11 @@ apt-get update
 ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     cmake ksh bash tzdata git gcc-12 \
-    autoconf automake libtool \
+    autoconf automake libtool curl \
     python3 python3-pip python3-venv python3-lib2to3
 dpkg-reconfigure --frontend noninteractive tzdata
+
+curl https://storage.googleapis.com/flywheel-dist/fw-cli/stable/install.sh | FW_CLI_INSTALL_DIR=/opt/flywheel-cli sh
 
 git clone https://github.com/brainsciencecenter/flywheel.git /opt/flywheel
 

--- a/apptainer/flywheel.def
+++ b/apptainer/flywheel.def
@@ -1,0 +1,45 @@
+# Filename: flywheel.def
+
+Bootstrap: docker
+From: ubuntu:22.04
+
+%environment
+
+export FLYWHEELDIR=/opt/flywheel
+export PYTHONPATH=/opt/flywheel/lib
+export PATH=/opt/flywheel/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+%post
+
+apt-get autoclean
+apt-get update
+ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    cmake ksh bash tzdata git gcc-12 \
+    autoconf automake libtool \
+    python3 python3-pip python3-venv python3-lib2to3
+dpkg-reconfigure --frontend noninteractive tzdata
+
+git clone https://github.com/brainsciencecenter/flywheel.git /opt/flywheel
+
+python3 -m venv /opt/venvs/flywheel
+
+. /opt/venvs/flywheel/bin/activate
+
+python3 -m pip install -U pip wheel setuptools
+
+python3 -m pip install pyjq
+
+python3 -m pip install \
+    flywheel-gear-toolkit \
+    flywheel-sdk \
+    globre \
+    numpy \
+    pandas \
+    pytz \
+    requests \
+    tzlocal
+
+%runscript
+
+. /opt/venvs/flywheel/bin/activate && "$@"


### PR DESCRIPTION
This change adds:

- an Apptainer/Singularity .def file for building a container with Flywheel installed; container uses Ubuntu 22.04
- a bash script to build the container, suitable for submission to Slurm on CUBIC
- a README file describing the contents of this directory

Addresses #20 